### PR TITLE
Fixed error in default creature skill creation

### DIFF
--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -85,7 +85,7 @@ export class HarnMasterActor extends Actor {
 
             // Add standard skills
             for (let pack in HM3.defaultCreatureSkills) {
-                await HarnMasterActor.addItemsFromPack(HM3.defaultCharacterSkills[pack], pack, updateData.items);
+                await HarnMasterActor.addItemsFromPack(HM3.defaultCreatureSkills[pack], pack, updateData.items);
             }
         } else if (createData.type === 'container') {
             updateData['data.capacity.max'] = 1;


### PR DESCRIPTION
I found my Creature Skill Overrides from hm-gold did not work until I checked the original actor.js code. It doesn't draw the default skills for a creature but instead uses the character default skills.  